### PR TITLE
Extend glyph ID system from u16 to u32 (20-bit base ID)

### DIFF
--- a/beamterm-atlas/src/coordinate.rs
+++ b/beamterm-atlas/src/coordinate.rs
@@ -4,7 +4,7 @@ use crate::glyph_bounds::GlyphBounds;
 
 #[derive(Debug, Clone, Copy)]
 pub(super) struct AtlasCoordinate {
-    pub(super) layer: u16,      // Depth in the 2D Texture Array
+    pub(super) layer: u32,      // Depth in the 2D Texture Array
     pub(super) glyph_index: u8, // 0..=31; each layer contains 32 glyphs
 }
 
@@ -22,10 +22,15 @@ impl AtlasCoordinate {
     }
 }
 
-impl From<u16> for AtlasCoordinate {
-    fn from(id: u16) -> Self {
+impl From<u32> for AtlasCoordinate {
+    fn from(id: u32) -> Self {
         // 32 glyphs per layer, indexed from 0 to 31
-        Self { layer: id >> 5, glyph_index: (id & 0x1F) as u8 }
+        // Extract base glyph ID (bits 0-19) first, then calculate layer
+        let base_id = id & 0x000FFFFF; // 20-bit base ID
+        Self { 
+            layer: (base_id >> 5) as u32, 
+            glyph_index: (base_id & 0x1F) as u8 
+        }
     }
 }
 

--- a/beamterm-atlas/src/verify_atlas_main.rs
+++ b/beamterm-atlas/src/verify_atlas_main.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn find_glyph_symbol(atlas: &FontAtlasData, slice: u16, pos: u16) -> Option<&Glyph> {
+fn find_glyph_symbol(atlas: &FontAtlasData, slice: u32, pos: u32) -> Option<&Glyph> {
     let glyph_id = (slice << 5) | pos; // 32 glyphs per slice (shift by 5 = multiply by 32)
     atlas.glyphs.iter().find(|g| g.id == glyph_id)
 }
@@ -170,7 +170,7 @@ fn render_cell(
             (false, false) => {
                 // Show glyph symbol at cell boundary
                 if x == 0 && y == 0 {
-                    if let Some(glyph) = find_glyph_symbol(atlas, slice as u16, cell_pos as u16) {
+                    if let Some(glyph) = find_glyph_symbol(atlas, slice as u32, cell_pos as u32) {
                         let ch = glyph.symbol.chars().next().unwrap_or(' ');
                         write!(output, "{}", ch.to_string().truecolor(0xfe, 0x80, 0x19)).ok();
                     } else {

--- a/beamterm-data/src/atlas.rs
+++ b/beamterm-data/src/atlas.rs
@@ -20,7 +20,7 @@ pub struct FontAtlasData {
     /// Fullwidth glyphs (e.g., CJK characters) are assigned IDs starting from this value,
     /// aligned to even boundaries. This allows the renderer to distinguish halfwidth from
     /// fullwidth glyphs by comparing against this threshold.
-    pub max_halfwidth_base_glyph_id: u16,
+    pub max_halfwidth_base_glyph_id: u32,
     /// Width, height and depth of the texture in pixels
     pub texture_dimensions: (i32, i32, i32),
     /// Width and height of each character cell

--- a/beamterm-data/src/serialization.rs
+++ b/beamterm-data/src/serialization.rs
@@ -3,7 +3,7 @@ use compact_str::{CompactString, format_compact};
 use crate::{FontAtlasData, FontStyle, Glyph, LineDecoration};
 
 const ATLAS_HEADER: [u8; 4] = [0xBA, 0xB1, 0xF0, 0xA7];
-const ATLAS_VERSION: u8 = 0x03; // dictates the format of the serialized data
+const ATLAS_VERSION: u8 = 0x04; // dictates the format of the serialized data (v4: u32 glyph IDs)
 
 #[derive(Debug)]
 pub struct SerializationError {
@@ -161,7 +161,7 @@ impl Serializable for CompactString {
 impl Serializable for Glyph {
     fn serialize(&self) -> Vec<u8> {
         let mut ser = Serializer::new();
-        ser.write_u16(self.id);
+        ser.write_u32(self.id);
         ser.write_u8(self.style.ordinal() as u8);
         ser.write_u8(self.is_emoji as u8);
         ser.write_i32(self.pixel_coords.0);
@@ -171,7 +171,7 @@ impl Serializable for Glyph {
     }
 
     fn deserialize(serialized: &mut Deserializer) -> Result<Self, SerializationError> {
-        let id = serialized.read_u16()?;
+        let id = serialized.read_u32()?;
         let style = serialized.read_u8()?;
         let is_emoji = serialized.read_u8()? != 0;
         let x = serialized.read_i32()?;
@@ -200,7 +200,7 @@ impl Serializable for FontAtlasData {
 
         ser.write_string(&self.font_name);
         ser.write_f32(self.font_size);
-        ser.write_u16(self.max_halfwidth_base_glyph_id);
+        ser.write_u32(self.max_halfwidth_base_glyph_id);
 
         ser.write_i32(self.texture_dimensions.0);
         ser.write_i32(self.texture_dimensions.1);
@@ -248,7 +248,7 @@ impl Serializable for FontAtlasData {
 
         let font_name = deser.read_string()?;
         let font_size = deser.read_f32()?;
-        let halfwidth_glyphs_per_layer = deser.read_u16()?;
+        let halfwidth_glyphs_per_layer = deser.read_u32()?;
 
         let texture_dimensions = (deser.read_i32()?, deser.read_i32()?, deser.read_i32()?);
         let cell_size = (deser.read_i32()?, deser.read_i32()?);

--- a/beamterm-renderer/src/gl/atlas.rs
+++ b/beamterm-renderer/src/gl/atlas.rs
@@ -27,9 +27,9 @@ pub struct FontAtlas {
     /// The underlying texture
     texture: crate::gl::texture::Texture,
     /// Symbol to 3d texture index
-    glyph_coords: HashMap<CompactString, u16>,
+    glyph_coords: HashMap<CompactString, u32>,
     /// Base glyph identifier to symbol mapping
-    symbol_lookup: HashMap<u16, CompactString>,
+    symbol_lookup: HashMap<u32, CompactString>,
     /// The size of each character cell in pixels
     cell_size: (i32, i32),
     /// The number of slices in the atlas texture
@@ -41,7 +41,7 @@ pub struct FontAtlas {
     /// Tracks glyphs that were requested but not found in the atlas
     glyph_tracker: GlyphTracker,
     /// The last assigned halfwidth base glyph ID, before fullwidth
-    last_halfwidth_base_glyph_id: u16,
+    last_halfwidth_base_glyph_id: u32,
 }
 
 impl FontAtlas {
@@ -121,14 +121,14 @@ impl FontAtlas {
     }
 
     /// Returns the symbol for the given glyph ID, if it exists
-    pub fn get_symbol(&self, glyph_id: u16) -> Option<Cow<'_, str>> {
+    pub fn get_symbol(&self, glyph_id: u32) -> Option<Cow<'_, str>> {
         let base_glyph_id = if glyph_id & Glyph::EMOJI_FLAG != 0 {
             glyph_id & Glyph::GLYPH_ID_EMOJI_MASK
         } else {
             glyph_id & Glyph::GLYPH_ID_MASK
         };
 
-        if (0x20..0x80).contains(&base_glyph_id) {
+        if (0x20..0x80).contains(&(base_glyph_id as u16)) {
             // ASCII characters are directly mapped to their code point
             let ch = base_glyph_id as u8 as char;
             Some(Cow::from(ch.to_compact_string()))
@@ -140,12 +140,12 @@ impl FontAtlas {
     }
 
     /// Returns the base glyph identifier for the given key
-    pub fn get_base_glyph_id(&self, key: &str) -> Option<u16> {
+    pub fn get_base_glyph_id(&self, key: &str) -> Option<u32> {
         if key.len() == 1 {
             let ch = key.chars().next().unwrap();
             if ch.is_ascii() {
                 // 0x00..0x7f double as layer
-                let id = ch as u16;
+                let id = ch as u32;
                 return Some(id);
             }
         }
@@ -160,7 +160,7 @@ impl FontAtlas {
     }
 
     /// Returns the maximum assigned halfwidth base glyph ID.
-    pub fn get_max_halfwidth_base_glyph_id(&self) -> u16 {
+    pub fn get_max_halfwidth_base_glyph_id(&self) -> u32 {
         self.last_halfwidth_base_glyph_id
     }
 
@@ -179,7 +179,7 @@ impl FontAtlas {
         ascii_count + non_ascii_count
     }
 
-    pub(crate) fn get_symbol_lookup(&self) -> &HashMap<u16, CompactString> {
+    pub(crate) fn get_symbol_lookup(&self) -> &HashMap<u32, CompactString> {
         &self.symbol_lookup
     }
 }

--- a/beamterm-renderer/src/shaders/cell.frag
+++ b/beamterm-renderer/src/shaders/cell.frag
@@ -27,13 +27,15 @@ void main() {
     uint glyph_index = v_glyph_index;
 
     // texture position from sequential index (32 glyphs per layer)
-    uint layer = (glyph_index & 0x1FFFu) >> 5u;
+    // 20-bit base ID: bits 0-19
+    uint layer = (glyph_index & 0xFFFFFu) >> 5u;
     uint pos_in_layer = glyph_index & 0x1Fu;
 
     // apply strikethrough or underline if the glyph has either bit set
+    // bit 23 = underline, bit 24 = strikethrough
     float line_alpha = max(
-        horizontal_line(v_tex_coord, u_underline_pos, u_underline_thickness) * float((glyph_index >> 13u) & 0x1u),
-        horizontal_line(v_tex_coord, u_strikethrough_pos, u_strikethrough_thickness) * float((glyph_index >> 14u) & 0x1u)
+        horizontal_line(v_tex_coord, u_underline_pos, u_underline_thickness) * float((glyph_index >> 23u) & 0x1u),
+        horizontal_line(v_tex_coord, u_strikethrough_pos, u_strikethrough_thickness) * float((glyph_index >> 24u) & 0x1u)
     );
 
     vec2 inner_tex_coord = v_tex_coord * (1.0 - 2.0 * u_padding_frac) + u_padding_frac;
@@ -49,7 +51,8 @@ void main() {
     vec4 glyph = texture(u_sampler, tex_coord);
 
     // 0.0 for normal glyphs, 1.0 for emojis
-    float emoji_factor = float((glyph_index >> 12u) & 0x1u);
+    // bit 22 = emoji flag
+    float emoji_factor = float((glyph_index >> 22u) & 0x1u);
 
     // color for normal glyphs are taken from the packed data;
     // emoji colors are sampled from the texture directly

--- a/beamterm-renderer/src/shaders/cell.vert
+++ b/beamterm-renderer/src/shaders/cell.vert
@@ -8,7 +8,8 @@ layout(location = 1) in vec2 a_tex_coord;
 
 // instance attributes
 layout(location = 2) in uvec2 a_instance_pos;
-layout(location = 3) in uvec2 a_packed_data;
+layout(location = 3) in uvec2 a_packed_data; // glyph_id + fg RGB
+layout(location = 4) in uvec2 a_packed_bg;   // bg RGB
 
 // uniforms
 layout(std140) uniform VertUbo {
@@ -31,18 +32,23 @@ float extract_byte(uint value, uint byte_pos) {
 
 void main() {
     v_tex_coord = a_tex_coord;
-    v_glyph_index = a_packed_data.x & 0xFFFFu;
+    // glyph_id is now full u32 in packed_data.x
+    v_glyph_index = a_packed_data.x;
 
     // extract colors in vertex shader to avoid ANGLE fragment shader bugs
+    // Layout:
+    // a_packed_data.x: glyph_id (4 bytes)
+    // a_packed_data.y: fg R (byte 0), fg G (byte 1), fg B (byte 2), padding (byte 3)
+    // a_packed_bg.x: bg R (byte 0), bg G (byte 1), bg B (byte 2), padding (byte 3)
     v_fg_color = vec3(
-        extract_byte(a_packed_data.x, 2u),
-        extract_byte(a_packed_data.x, 3u),
-        extract_byte(a_packed_data.y, 0u)
+        extract_byte(a_packed_data.y, 0u), // fg R
+        extract_byte(a_packed_data.y, 1u), // fg G
+        extract_byte(a_packed_data.y, 2u)  // fg B
     );
     v_bg_color = vec3(
-        extract_byte(a_packed_data.y, 1u),
-        extract_byte(a_packed_data.y, 2u),
-        extract_byte(a_packed_data.y, 3u)
+        extract_byte(a_packed_bg.x, 0u), // bg R
+        extract_byte(a_packed_bg.x, 1u), // bg G
+        extract_byte(a_packed_bg.x, 2u)  // bg B
     );
 
     vec2 offset = vec2(

--- a/beamterm-renderer/src/terminal.rs
+++ b/beamterm-renderer/src/terminal.rs
@@ -479,7 +479,7 @@ impl TerminalDebugApi {
 
     /// Returns the base glyph ID for a given symbol, or null if not found.
     #[wasm_bindgen(js_name = "getBaseGlyphId")]
-    pub fn get_base_glyph_id(&self, symbol: &str) -> Option<u16> {
+    pub fn get_base_glyph_id(&self, symbol: &str) -> Option<u32> {
         self.grid
             .borrow()
             .atlas()
@@ -488,7 +488,7 @@ impl TerminalDebugApi {
 
     /// Returns the symbol for a given glyph ID, or null if not found.
     #[wasm_bindgen(js_name = "getSymbol")]
-    pub fn get_symbol(&self, glyph_id: u16) -> Option<String> {
+    pub fn get_symbol(&self, glyph_id: u32) -> Option<String> {
         self.grid
             .borrow()
             .atlas()


### PR DESCRIPTION
- Changed Glyph::id from u16 to u32
- Updated GLYPH_ID_MASK from 0x03FF (10 bits, 1024 glyphs) to 0xFFFFF (20 bits, 1M glyphs)
- Shifted style flags (BOLD, ITALIC, EMOJI, UNDERLINE, STRIKETHROUGH) to accommodate larger ID
- Updated shaders (cell.vert, cell.frag) to handle u32 glyph IDs and new bit positions
- Updated CellDynamic struct to 16 bytes to pack u32 glyph ID + colors (uvec4)
- Updated serialization version to 0x04 for backward compatibility
- Updated atlas generator, renderer, and coordinate system to use u32
- Removed assertions limiting glyph count in grapheme.rs

This change enables support for full Nerd Fonts icon set and emoji ranges without requiring dynamic atlas expansion.