### PR TITLE
fix(dynamic-atlas): handle ASCII characters in `get_symbol()`

### DIFF
--- a/beamterm-renderer/src/gl/dynamic_atlas.rs
+++ b/beamterm-renderer/src/gl/dynamic_atlas.rs
@@ -253,10 +253,17 @@ impl Atlas for DynamicFontAtlas {
     }
 
     fn get_symbol(&self, glyph_id: u16) -> Option<CompactString> {
-        self.symbol_lookup
-            .borrow()
-            .get(&glyph_id)
-            .cloned()
+        // ASCII characters (slots 0-94) are directly mapped: slot_id = codepoint - 0x20
+        // This matches upload_ascii_glyphs() which assigns slots 0-94 for 0x20-0x7E
+        if glyph_id < 95 {
+            let ch = (glyph_id + 0x20) as u8 as char;
+            Some(ch.to_compact_string())
+        } else {
+            self.symbol_lookup
+                .borrow()
+                .get(&glyph_id)
+                .cloned()
+        }
     }
 
     fn glyph_tracker(&self) -> &GlyphTracker {


### PR DESCRIPTION
The `get_symbol()` method in `DynamicFontAtlas` was not returning symbols for ASCII characters (0x20-0x7E). This caused text selection to only copy non-ASCII characters (emoji, special symbols) while ignoring regular ASCII text.

The issue was that `upload_ascii_glyphs()` uploads ASCII glyphs to slots 0-94 but doesn't add them to `symbol_lookup` HashMap. The `get_symbol()` method only checked `symbol_lookup`, missing all ASCII.

The fix adds special handling for ASCII slots (0-94) that mirrors the implementation in `static_atlas.rs`:
- Slots 0-94 map directly to codepoints 0x20-0x7E
- Symbol is computed as: (slot_id + 0x20) as char

This ensures text selection works correctly for all characters.