### PR TITLE
fix(examples): register critical-section impl for canvas_waves wasm build

### DIFF
--- a/examples/canvas_waves/Cargo.toml
+++ b/examples/canvas_waves/Cargo.toml
@@ -8,6 +8,10 @@ publish = false
 ratzilla = { git = "https://github.com/orhun/ratzilla", branch = "main" }
 # ratzilla = { path = "../../../ratzilla" }
 console_error_panic_hook = "0.1.7"
+# ratatui_core (via ratzilla/tachyonfx) needs a registered critical-section impl
+# on wasm32; the std impl provides it. Without this the wasm link fails with
+# `undefined symbol: _critical_section_1_0_acquire`.
+critical-section = { version = "1.1", features = ["std"] }
 tachyonfx = { version = "0.25.0", default-features = false, features = ["wasm"] }
 web-time = "1.1.0"
 web-sys = { version = "0.3", features = ["Window", "Location", "UrlSearchParams"] }


### PR DESCRIPTION
## Problem

`examples/canvas_waves` fails to build for `wasm32-unknown-unknown` (and thus the GitHub Pages deploy fails at the `Build examples` step):

```
rust-lld: error: ...libratatui_core-*.rlib(...): undefined symbol: _critical_section_1_0_acquire
rust-lld: error: ...libratatui_core-*.rlib(...): undefined symbol: _critical_section_1_0_release
```

The example has no committed lockfile, so a fresh resolve pulls a current `ratatui_core` (via `ratzilla`/`tachyonfx`) that depends on `critical-section`. On `wasm32-unknown-unknown` nothing registers a `critical-section` implementation, so the linker can't resolve the `acquire`/`release` symbols.

## Fix

Add `critical-section` with the `std` feature to `canvas_waves`, which registers the implementation:

```toml
critical-section = { version = "1.1", features = ["std"] }
```

After this, `cargo build --release --target wasm32-unknown-unknown` (and `trunk build`) link cleanly.

## Notes

- This is pre-existing dependency drift, independent of any feature work — reproducible on a fresh checkout + build of `main`.
- Single-file change to the example's `Cargo.toml`; no library code touched.